### PR TITLE
Added direct support for Shelly Gen2+ devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2024-12-10 by jjdejong
+* Added direct support for Shelly gen2+ devices
+
 ## v1.0.9-dev
 * Changed: Broker port missing on reconnect
 * Changed: Default device instance is now `100`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.9-dev
 * Changed: Broker port missing on reconnect
+* Changed: Default device instance is now `100`
 * Changed: Fixed service not starting sometimes
 
 ## v0.1.8

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Copy or rename the `config.sample.ini` to `config.ini` in the `dbus-mqtt-pv` fol
 
 ## JSON structure
 
+### Generic version
+
 <details><summary>Minimum required</summary>
 
 ```json
@@ -139,6 +141,20 @@ Copy or rename the `config.sample.ini` to `config.ini` in the `dbus-mqtt-pv` fol
 ```
 </details>
 
+### Shelly version (Gen 2+)
+
+```json
+ {
+    "apower": 0.0, 
+    "voltage": ..., 
+    "current": ..., 
+    "freq": ..., 
+    "aenergy": { 
+        "total": ... 
+    }
+}
+```
+In the `config.ini` file, set `shelly = true`, and set your shelly device to use the same topic as the one configured in `config.ini`. Don't forget to enable MQTT on your Shelly device and correctly set the host, port and topic.
 
 ## Home Assistant
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@
 1. [Config](#config)
 1. [JSON structure](#json-structure)
 1. [Home Assistant](#home-assistant)
-1. [Install](#install)
+1. [Install / Update](#install--update)
 1. [Uninstall](#uninstall)
 1. [Restart](#restart)
 1. [Debugging](#debugging)
-1. [Multiple instances](#multiple-instances)
 1. [Compatibility](#compatibility)
 1. [Screenshots](#screenshots)
 
@@ -176,61 +175,86 @@ action:
 In the `config.ini` of `dbus-mqtt-pv` set the MQTT broker to the Home Assistant hostname/IP and the topic to the same as in your Home Assistant config (like above).
 
 
-## Install
+## Install / Update
 
 1. Login to your Venus OS device via SSH. See [Venus OS:Root Access](https://www.victronenergy.com/live/ccgx:root_access#root_access) for more details.
 
-2. Execute this commands to download and extract the files:
+2. Execute this commands to download and copy the files:
 
     ```bash
-    # change to temp folder
-    cd /tmp
+    wget -O /tmp/download_dbus-mqtt-pv.sh https://raw.githubusercontent.com/mr-manuel/venus-os_dbus-mqtt-pv/master/download.sh
 
-    # download driver
-    wget -O /tmp/venus-os_dbus-mqtt-pv.zip https://github.com/mr-manuel/venus-os_dbus-mqtt-pv/archive/refs/heads/master.zip
-
-    # If updating: cleanup old folder
-    rm -rf /tmp/venus-os_dbus-mqtt-pv-master
-
-    # unzip folder
-    unzip venus-os_dbus-mqtt-pv.zip
-
-    # If updating: backup existing config file
-    mv /data/etc/dbus-mqtt-pv/config.ini /data/etc/dbus-mqtt-pv_config.ini
-
-    # If updating: cleanup existing driver
-    rm -rf /data/etc/dbus-mqtt-pv
-
-    # copy files
-    cp -R /tmp/venus-os_dbus-mqtt-pv-master/dbus-mqtt-pv/ /data/etc/
-
-    # If updating: restore existing config file
-    mv /data/etc/dbus-mqtt-pv_config.ini /data/etc/dbus-mqtt-pv/config.ini
+    bash /tmp/download_dbus-mqtt-pv.sh
     ```
 
-3. Copy the sample config file, if you are installing the driver for the first time and edit it to your needs.
+3. Select the version you want to install.
 
+4. Press enter for a single instance. For multiple instances, enter a number and press enter.
+
+    Example:
+
+    - Pressing enter or entering `1` will install the driver to `/data/etc/dbus-mqtt-pv`.
+    - Entering `2` will install the driver to `/data/etc/dbus-mqtt-pv-2`.
+
+### Extra steps for your first installation
+
+5. Edit the config file to fit your needs. The correct command for your installation is shown after the installation.
+
+    - If you pressed enter or entered `1` during installation:
     ```bash
-    # copy default config file
-    cp /data/etc/dbus-mqtt-pv/config.sample.ini /data/etc/dbus-mqtt-pv/config.ini
-
-    # edit the config file with nano
     nano /data/etc/dbus-mqtt-pv/config.ini
     ```
 
-4. Run `bash /data/etc/dbus-mqtt-pv/install.sh` to install the driver as service.
+    - If you entered `2` during installation:
+    ```bash
+    nano /data/etc/dbus-mqtt-pv-2/config.ini
+    ```
 
-   The daemon-tools should start this service automatically within seconds.
+6. Install the driver as a service. The correct command for your installation is shown after the installation.
+
+    - If you pressed enter or entered `1` during installation:
+    ```bash
+    bash /data/etc/dbus-mqtt-pv/install.sh
+    ```
+
+    - If you entered `2` during installation:
+    ```bash
+    bash /data/etc/dbus-mqtt-pv-2/install.sh
+    ```
+
+    The daemon-tools should start this service automatically within seconds.
 
 ## Uninstall
 
-Run `/data/etc/dbus-mqtt-pv/uninstall.sh`
+⚠️ If you have multiple instances, ensure you choose the correct one. For example:
+
+- To uninstall the default instance:
+    ```bash
+    bash /data/etc/dbus-mqtt-pv/uninstall.sh
+    ```
+
+- To uninstall the second instance:
+    ```bash
+    bash /data/etc/dbus-mqtt-pv-2/uninstall.sh
+    ```
 
 ## Restart
 
-Run `/data/etc/dbus-mqtt-pv/restart.sh`
+⚠️ If you have multiple instances, ensure you choose the correct one. For example:
+
+- To restart the default instance:
+    ```bash
+    bash /data/etc/dbus-mqtt-pv/restart.sh
+    ```
+
+- To restart the second instance:
+    ```bash
+    bash /data/etc/dbus-mqtt-pv-2/restart.sh
+    ```
 
 ## Debugging
+
+⚠️ If you have multiple instances, ensure you choose the correct one.
 
 The logs can be checked with `tail -n 100 -f /data/log/dbus-mqtt-pv/current | tai64nlocal`
 
@@ -242,32 +266,9 @@ If the seconds are under 5 then the service crashes and gets restarted all the t
 
 If the script stops with the message `dbus.exceptions.NameExistsException: Bus name already exists: com.victronenergy.pvinverter.mqtt_pv"` it means that the service is still running or another service is using that bus name.
 
-## Multiple instances
-
-It's possible to have multiple instances, but it's not automated. Follow these steps to achieve this:
-
-1. Save the new name to a variable `driverclone=dbus-mqtt-pv-2`
-
-2. Copy current folder `cp -r /data/etc/dbus-mqtt-pv/ /data/etc/$driverclone/`
-
-3. Rename the main script `mv /data/etc/$driverclone/dbus-mqtt-pv.py /data/etc/$driverclone/$driverclone.py`
-
-4. Fix the script references for service and log
-    ```
-    sed -i 's:dbus-mqtt-pv:'$driverclone':g' /data/etc/$driverclone/service/run
-    sed -i 's:dbus-mqtt-pv:'$driverclone':g' /data/etc/$driverclone/service/log/run
-    ```
-
-5. Change the `device_name`, increase the `device_instance` and update the `topic` in the `config.ini`
-
-Now you can install and run the cloned driver. Should you need another instance just increase the number in step 1 and repeat all steps.
-
 ## Compatibility
 
-It was tested on Venus OS Large `v2.92` on the following devices:
-
-* RaspberryPi 4b
-* MultiPlus II (GX Version)
+This software supports the latest three stable versions of Venus OS. It may also work on older versions, but this is not guaranteed.
 
 ## Screenshots
 

--- a/dbus-mqtt-pv/config.sample.ini
+++ b/dbus-mqtt-pv/config.sample.ini
@@ -16,8 +16,8 @@ logging = WARNING
 device_name = MQTT PV
 
 ; Device VRM instance
-; default: 51
-device_instance = 51
+; default: 100
+device_instance = 100
 
 ; Specify after how many seconds the driver should exit (disconnect), if no new MQTT message was received
 ; default: 60

--- a/dbus-mqtt-pv/config.sample.ini
+++ b/dbus-mqtt-pv/config.sample.ini
@@ -30,6 +30,9 @@ voltage = 230
 ; used when no frequency is received
 frequency = 50
 
+; set to true for Shelly meters
+shelly = true
+
 
 [PV]
 ; Max rated power (in Watts) of the inverter
@@ -69,6 +72,12 @@ broker_port = 1883
 ; Password used for connection
 ;password = mypassword
 
-; Topic where the pv data as JSON string is published
-; minimum required JSON payload: {"pv": { "power": 0.0 } }
-topic = enphase/envoy-s/meters
+; Whatever topic where your device publishes the pv data as a JSON string
+;
+; For Shelly devices, set the "MQTT Prefix" to "shellies/your-device-name". Then the topic is:
+;   - "shellies/your-device-name/status/pm1:0" for PM devices or 
+;   - "shellies/your-device-name/status/switch:0" for 1PM devices.
+; You can set the MQTT Prefix to whatever you want, just make sure you use the corresponding topic here.
+;
+; Minimum required JSON payload: {"pv": { "power": 0.0 } } (or { "apower": 0.0 } for Shelly devices)
+topic = shellies/your-device-name/status/pm1:0

--- a/dbus-mqtt-pv/dbus-mqtt-pv.py
+++ b/dbus-mqtt-pv/dbus-mqtt-pv.py
@@ -388,46 +388,24 @@ def main():
     if "tls_enabled" in config["MQTT"] and config["MQTT"]["tls_enabled"] == "1":
         logging.info("MQTT client: TLS is enabled")
 
-        if (
-            "tls_path_to_ca" in config["MQTT"]
-            and config["MQTT"]["tls_path_to_ca"] != ""
-        ):
-            logging.info(
-                'MQTT client: TLS: custom ca "%s" used'
-                % config["MQTT"]["tls_path_to_ca"]
-            )
+        if "tls_path_to_ca" in config["MQTT"] and config["MQTT"]["tls_path_to_ca"] != "":
+            logging.info('MQTT client: TLS: custom ca "%s" used' % config["MQTT"]["tls_path_to_ca"])
             client.tls_set(config["MQTT"]["tls_path_to_ca"], tls_version=2)
         else:
             client.tls_set(tls_version=2)
 
         if "tls_insecure" in config["MQTT"] and config["MQTT"]["tls_insecure"] != "":
-            logging.info(
-                "MQTT client: TLS certificate server hostname verification disabled"
-            )
+            logging.info("MQTT client: TLS certificate server hostname verification disabled")
             client.tls_insecure_set(True)
 
     # check if username and password are set
-    if (
-        "username" in config["MQTT"]
-        and "password" in config["MQTT"]
-        and config["MQTT"]["username"] != ""
-        and config["MQTT"]["password"] != ""
-    ):
-        logging.info(
-            'MQTT client: Using username "%s" and password to connect'
-            % config["MQTT"]["username"]
-        )
-        client.username_pw_set(
-            username=config["MQTT"]["username"], password=config["MQTT"]["password"]
-        )
+    if "username" in config["MQTT"] and "password" in config["MQTT"] and config["MQTT"]["username"] != "" and config["MQTT"]["password"] != "":
+        logging.info('MQTT client: Using username "%s" and password to connect' % config["MQTT"]["username"])
+        client.username_pw_set(username=config["MQTT"]["username"], password=config["MQTT"]["password"])
 
     # connect to broker
-    logging.info(
-        f"MQTT client: Connecting to broker {config['MQTT']['broker_address']} on port {config['MQTT']['broker_port']}"
-    )
-    client.connect(
-        host=config["MQTT"]["broker_address"], port=int(config["MQTT"]["broker_port"])
-    )
+    logging.info(f"MQTT client: Connecting to broker {config['MQTT']['broker_address']} on port {config['MQTT']['broker_port']}")
+    client.connect(host=config["MQTT"]["broker_address"], port=int(config["MQTT"]["broker_port"]))
     client.loop_start()
 
     # wait to receive first data, else the JSON is empty and phase setup won't work

--- a/dbus-mqtt-pv/dbus-mqtt-pv.py
+++ b/dbus-mqtt-pv/dbus-mqtt-pv.py
@@ -24,17 +24,11 @@ try:
         config = configparser.ConfigParser()
         config.read(config_file)
         if config["MQTT"]["broker_address"] == "IP_ADDR_OR_FQDN":
-            print(
-                'ERROR:The "config.ini" is using invalid default values like IP_ADDR_OR_FQDN. The driver restarts in 60 seconds.'
-            )
+            print('ERROR:The "config.ini" is using invalid default values like IP_ADDR_OR_FQDN. The driver restarts in 60 seconds.')
             sleep(60)
             sys.exit()
     else:
-        print(
-            'ERROR:The "'
-            + config_file
-            + '" is not found. Did you copy or rename the "config.sample.ini" to "config.ini"? The driver restarts in 60 seconds.'
-        )
+        print('ERROR:The "' + config_file + '" is not found. Did you copy or rename the "config.sample.ini" to "config.ini"? The driver restarts in 60 seconds.')
         sleep(60)
         sys.exit()
 
@@ -42,9 +36,7 @@ except Exception:
     exception_type, exception_object, exception_traceback = sys.exc_info()
     file = exception_traceback.tb_frame.f_code.co_filename
     line = exception_traceback.tb_lineno
-    print(
-        f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}"
-    )
+    print(f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}")
     print("ERROR:The driver restarts in 60 seconds.")
     sleep(60)
     sys.exit()
@@ -109,21 +101,17 @@ def on_disconnect(client, userdata, rc):
     global connected
     logging.warning("MQTT client: Got disconnected")
     if rc != 0:
-        logging.warning(
-            "MQTT client: Unexpected MQTT disconnection. Will auto-reconnect"
-        )
+        logging.warning("MQTT client: Unexpected MQTT disconnection. Will auto-reconnect")
     else:
         logging.warning("MQTT client: rc value:" + str(rc))
 
     while connected == 0:
         try:
-            logging.warning("MQTT client: Trying to reconnect")
-            client.connect(config["MQTT"]["broker_address"])
+            logging.warning(f"MQTT client: Trying to reconnect to broker {config['MQTT']['broker_address']} on port {config['MQTT']['broker_port']}")
+            client.connect(host=config["MQTT"]["broker_address"], port=int(config["MQTT"]["broker_port"]))
             connected = 1
         except Exception as err:
-            logging.error(
-                f"MQTT client: Error in retrying to connect with broker ({config['MQTT']['broker_address']}:{config['MQTT']['broker_port']}): {err}"
-            )
+            logging.error(f"MQTT client: Error in retrying to connect with broker ({config['MQTT']['broker_address']}:{config['MQTT']['broker_port']}): {err}")
             logging.error("MQTT client: Retrying in 15 seconds")
             connected = 0
             sleep(15)
@@ -190,117 +178,48 @@ def on_message(client, userdata, msg):
                 
                 else:
                     if "pv" in jsonpayload:
-                        if (
-                            isinstance(jsonpayload["pv"], dict)
-                            and "power" in jsonpayload["pv"]
-                        ):
+                        if isinstance(jsonpayload["pv"], dict) and "power" in jsonpayload["pv"]:
                             pv_power = float(jsonpayload["pv"]["power"])
-                            pv_current = (
-                                float(jsonpayload["pv"]["current"])
-                                if "current" in jsonpayload["pv"]
-                                else pv_power / float(config["DEFAULT"]["voltage"])
-                            )
-                            pv_voltage = (
-                                float(jsonpayload["pv"]["voltage"])
-                                if "voltage" in jsonpayload["pv"]
-                                else float(config["DEFAULT"]["voltage"])
-                            )
+                            pv_current = float(jsonpayload["pv"]["current"]) if "current" in jsonpayload["pv"] else pv_power / float(config["DEFAULT"]["voltage"])
+                            pv_voltage = float(jsonpayload["pv"]["voltage"]) if "voltage" in jsonpayload["pv"] else float(config["DEFAULT"]["voltage"])
                             if "energy_forward" in jsonpayload["pv"]:
                                 pv_forward = float(jsonpayload["pv"]["energy_forward"])
 
-                            # check if L1 and L1 -> power exists
-                            if (
-                                "L1" in jsonpayload["pv"]
-                                and "power" in jsonpayload["pv"]["L1"]
-                            ):
+                                # check if L1 and L1 -> power exists
+                            if "L1" in jsonpayload["pv"] and "power" in jsonpayload["pv"]["L1"]:
                                 pv_L1_power = float(jsonpayload["pv"]["L1"]["power"])
-                                pv_L1_current = (
-                                    float(jsonpayload["pv"]["L1"]["current"])
-                                    if "current" in jsonpayload["pv"]["L1"]
-                                    else pv_L1_power / float(config["DEFAULT"]["voltage"])
-                                )
-                                pv_L1_voltage = (
-                                    float(jsonpayload["pv"]["L1"]["voltage"])
-                                    if "voltage" in jsonpayload["pv"]["L1"]
-                                    else float(config["DEFAULT"]["voltage"])
-                                )
-                                pv_L1_frequency = (
-                                    float(jsonpayload["pv"]["L1"]["frequency"])
-                                    if "frequency" in jsonpayload["pv"]["L1"]
-                                    else float(config["DEFAULT"]["frequency"])
-                                )
+                                pv_L1_current = float(jsonpayload["pv"]["L1"]["current"]) if "current" in jsonpayload["pv"]["L1"] else pv_L1_power / float(config["DEFAULT"]["voltage"])
+                                pv_L1_voltage = float(jsonpayload["pv"]["L1"]["voltage"]) if "voltage" in jsonpayload["pv"]["L1"] else float(config["DEFAULT"]["voltage"])
+                                pv_L1_frequency = float(jsonpayload["pv"]["L1"]["frequency"]) if "frequency" in jsonpayload["pv"]["L1"] else float(config["DEFAULT"]["frequency"])
                                 if "energy_forward" in jsonpayload["pv"]["L1"]:
-                                    pv_L1_forward = float(
-                                        jsonpayload["pv"]["L1"]["energy_forward"]
-                                    )
+                                    pv_L1_forward = float(jsonpayload["pv"]["L1"]["energy_forward"])
 
-                            # check if L2 and L2 -> power exists
-                            if (
-                                "L2" in jsonpayload["pv"]
-                                and "power" in jsonpayload["pv"]["L2"]
-                            ):
+                                # check if L2 and L2 -> power exists
+                            if "L2" in jsonpayload["pv"] and "power" in jsonpayload["pv"]["L2"]:
                                 pv_L2_power = float(jsonpayload["pv"]["L2"]["power"])
-                                pv_L2_current = (
-                                    float(jsonpayload["pv"]["L2"]["current"])
-                                    if "current" in jsonpayload["pv"]["L2"]
-                                    else pv_L2_power / float(config["DEFAULT"]["voltage"])
-                                )
-                                pv_L2_voltage = (
-                                    float(jsonpayload["pv"]["L2"]["voltage"])
-                                    if "voltage" in jsonpayload["pv"]["L2"]
-                                    else float(config["DEFAULT"]["voltage"])
-                                )
-                                pv_L2_frequency = (
-                                    float(jsonpayload["pv"]["L2"]["frequency"])
-                                    if "frequency" in jsonpayload["pv"]["L2"]
-                                    else float(config["DEFAULT"]["frequency"])
-                                )
+                                pv_L2_current = float(jsonpayload["pv"]["L2"]["current"]) if "current" in jsonpayload["pv"]["L2"] else pv_L2_power / float(config["DEFAULT"]["voltage"])
+                                pv_L2_voltage = float(jsonpayload["pv"]["L2"]["voltage"]) if "voltage" in jsonpayload["pv"]["L2"] else float(config["DEFAULT"]["voltage"])
+                                pv_L2_frequency = float(jsonpayload["pv"]["L2"]["frequency"]) if "frequency" in jsonpayload["pv"]["L2"] else float(config["DEFAULT"]["frequency"])
                                 if "energy_forward" in jsonpayload["pv"]["L2"]:
-                                    pv_L2_forward = float(
-                                        jsonpayload["pv"]["L2"]["energy_forward"]
-                                    )
+                                    pv_L2_forward = float(jsonpayload["pv"]["L2"]["energy_forward"])
 
-                            # check if L3 and L3 -> power exists
-                            if (
-                                "L3" in jsonpayload["pv"]
-                                and "power" in jsonpayload["pv"]["L3"]
-                            ):
+                                # check if L3 and L3 -> power exists
+                            if "L3" in jsonpayload["pv"] and "power" in jsonpayload["pv"]["L3"]:
                                 pv_L3_power = float(jsonpayload["pv"]["L3"]["power"])
-                                pv_L3_current = (
-                                    float(jsonpayload["pv"]["L3"]["current"])
-                                    if "current" in jsonpayload["pv"]["L3"]
-                                    else pv_L3_power / float(config["DEFAULT"]["voltage"])
-                                )
-                                pv_L3_voltage = (
-                                    float(jsonpayload["pv"]["L3"]["voltage"])
-                                    if "voltage" in jsonpayload["pv"]["L3"]
-                                    else float(config["DEFAULT"]["voltage"])
-                                )
-                                pv_L3_frequency = (
-                                    float(jsonpayload["pv"]["L3"]["frequency"])
-                                    if "frequency" in jsonpayload["pv"]["L3"]
-                                    else float(config["DEFAULT"]["frequency"])
-                                )
+                                pv_L3_current = float(jsonpayload["pv"]["L3"]["current"]) if "current" in jsonpayload["pv"]["L3"] else pv_L3_power / float(config["DEFAULT"]["voltage"])
+                                pv_L3_voltage = float(jsonpayload["pv"]["L3"]["voltage"]) if "voltage" in jsonpayload["pv"]["L3"] else float(config["DEFAULT"]["voltage"])
+                                pv_L3_frequency = float(jsonpayload["pv"]["L3"]["frequency"]) if "frequency" in jsonpayload["pv"]["L3"] else float(config["DEFAULT"]["frequency"])
                                 if "energy_forward" in jsonpayload["pv"]["L3"]:
-                                    pv_L3_forward = float(
-                                        jsonpayload["pv"]["L3"]["energy_forward"]
-                                    )
+                                    pv_L3_forward = float(jsonpayload["pv"]["L3"]["energy_forward"])
                         else:
-                            logging.error(
-                                'Received JSON MQTT message does not include a power object in the pv object. Expected at least: {"pv": {"power": 0.0}"}'
-                            )
+                            logging.error('Received JSON MQTT message does not include a power object in the pv object. Expected at least: {"pv": {"power": 0.0}}')
                             logging.debug("MQTT payload: " + str(msg.payload)[1:])
-
                     else:
-                        logging.error(
-                            'Received JSON MQTT message does not include a pv object. Expected at least: {"pv": {"power": 0.0}"}'
-                        )
+                        logging.error('Received JSON MQTT message does not include a pv object. Expected at least: {"pv": {"power": 0.0}}')
                         logging.debug("MQTT payload: " + str(msg.payload)[1:])
 
             else:
-                logging.warning(
-                    "Received JSON MQTT message was empty and therefore it was ignored"
-                )
+                logging.warning("Received JSON MQTT message was empty and therefore it was ignored")
                 logging.debug("MQTT payload: " + str(msg.payload)[1:])
 
     except TypeError as e:
@@ -315,9 +234,7 @@ def on_message(client, userdata, msg):
         exception_type, exception_object, exception_traceback = sys.exc_info()
         file = exception_traceback.tb_frame.f_code.co_filename
         line = exception_traceback.tb_lineno
-        logging.error(
-            f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}"
-        )
+        logging.error(f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}")
         logging.debug("MQTT payload: " + str(msg.payload)[1:])
 
 
@@ -381,108 +298,46 @@ class DbusMqttPvService:
 
         if last_changed != last_updated:
 
-            self._dbusservice["/Ac/Power"] = (
-                round(pv_power, 2) if pv_power is not None else None
-            )
-            self._dbusservice["/Ac/Current"] = (
-                round(pv_current, 2) if pv_current is not None else None
-            )
-            self._dbusservice["/Ac/Voltage"] = (
-                round(pv_voltage, 2) if pv_voltage is not None else None
-            )
-            self._dbusservice["/Ac/Energy/Forward"] = (
-                round(pv_forward, 2) if pv_forward is not None else None
-            )
+            self._dbusservice["/Ac/Power"] = round(pv_power, 2) if pv_power is not None else None
+            self._dbusservice["/Ac/Current"] = round(pv_current, 2) if pv_current is not None else None
+            self._dbusservice["/Ac/Voltage"] = round(pv_voltage, 2) if pv_voltage is not None else None
+            self._dbusservice["/Ac/Energy/Forward"] = round(pv_forward, 2) if pv_forward is not None else None
 
             if pv_L1_power is not None:
-                self._dbusservice["/Ac/L1/Power"] = (
-                    round(pv_L1_power, 2) if pv_L1_power is not None else None
-                )
-                self._dbusservice["/Ac/L1/Current"] = (
-                    round(pv_L1_current, 2) if pv_L1_current is not None else None
-                )
-                self._dbusservice["/Ac/L1/Voltage"] = (
-                    round(pv_L1_voltage, 2) if pv_L1_voltage is not None else None
-                )
-                self._dbusservice["/Ac/L1/Frequency"] = (
-                    round(pv_L1_frequency, 2) if pv_L1_frequency is not None else None
-                )
-                self._dbusservice["/Ac/L1/Energy/Forward"] = (
-                    round(pv_L1_forward, 2) if pv_L1_forward is not None else None
-                )
+                self._dbusservice["/Ac/L1/Power"] = round(pv_L1_power, 2) if pv_L1_power is not None else None
+                self._dbusservice["/Ac/L1/Current"] = round(pv_L1_current, 2) if pv_L1_current is not None else None
+                self._dbusservice["/Ac/L1/Voltage"] = round(pv_L1_voltage, 2) if pv_L1_voltage is not None else None
+                self._dbusservice["/Ac/L1/Frequency"] = round(pv_L1_frequency, 2) if pv_L1_frequency is not None else None
+                self._dbusservice["/Ac/L1/Energy/Forward"] = round(pv_L1_forward, 2) if pv_L1_forward is not None else None
             # at least one phase is needed to work properly
             elif pv_L2_power is None and pv_L3_power is None:
-                self._dbusservice["/Ac/L1/Power"] = (
-                    round(pv_power, 2) if pv_power is not None else None
-                )
-                self._dbusservice["/Ac/L1/Current"] = (
-                    round(pv_current, 2) if pv_current is not None else None
-                )
-                self._dbusservice["/Ac/L1/Voltage"] = (
-                    round(pv_voltage, 2) if pv_voltage is not None else None
-                )
+                self._dbusservice["/Ac/L1/Power"] = round(pv_power, 2) if pv_power is not None else None
+                self._dbusservice["/Ac/L1/Current"] = round(pv_current, 2) if pv_current is not None else None
+                self._dbusservice["/Ac/L1/Voltage"] = round(pv_voltage, 2) if pv_voltage is not None else None
                 self._dbusservice["/Ac/L1/Frequency"] = None
-                self._dbusservice["/Ac/L1/Energy/Forward"] = (
-                    round(pv_forward, 2) if pv_forward is not None else None
-                )
+                self._dbusservice["/Ac/L1/Energy/Forward"] = round(pv_forward, 2) if pv_forward is not None else None
 
             if pv_L2_power is not None:
-                self._dbusservice["/Ac/L2/Power"] = (
-                    round(pv_L2_power, 2) if pv_L2_power is not None else None
-                )
-                self._dbusservice["/Ac/L2/Current"] = (
-                    round(pv_L2_current, 2) if pv_L2_current is not None else None
-                )
-                self._dbusservice["/Ac/L2/Voltage"] = (
-                    round(pv_L2_voltage, 2) if pv_L2_voltage is not None else None
-                )
-                self._dbusservice["/Ac/L2/Frequency"] = (
-                    round(pv_L2_frequency, 2) if pv_L2_frequency is not None else None
-                )
-                self._dbusservice["/Ac/L2/Energy/Forward"] = (
-                    round(pv_L2_forward, 2) if pv_L2_forward is not None else None
-                )
+                self._dbusservice["/Ac/L2/Power"] = round(pv_L2_power, 2) if pv_L2_power is not None else None
+                self._dbusservice["/Ac/L2/Current"] = round(pv_L2_current, 2) if pv_L2_current is not None else None
+                self._dbusservice["/Ac/L2/Voltage"] = round(pv_L2_voltage, 2) if pv_L2_voltage is not None else None
+                self._dbusservice["/Ac/L2/Frequency"] = round(pv_L2_frequency, 2) if pv_L2_frequency is not None else None
+                self._dbusservice["/Ac/L2/Energy/Forward"] = round(pv_L2_forward, 2) if pv_L2_forward is not None else None
 
             if pv_L3_power is not None:
-                self._dbusservice["/Ac/L3/Power"] = (
-                    round(pv_L3_power, 2) if pv_L3_power is not None else None
-                )
-                self._dbusservice["/Ac/L3/Current"] = (
-                    round(pv_L3_current, 2) if pv_L3_current is not None else None
-                )
-                self._dbusservice["/Ac/L3/Voltage"] = (
-                    round(pv_L3_voltage, 2) if pv_L3_voltage is not None else None
-                )
-                self._dbusservice["/Ac/L3/Frequency"] = (
-                    round(pv_L3_frequency, 2) if pv_L3_frequency is not None else None
-                )
-                self._dbusservice["/Ac/L3/Energy/Forward"] = (
-                    round(pv_L3_forward, 2) if pv_L3_forward is not None else None
-                )
+                self._dbusservice["/Ac/L3/Power"] = round(pv_L3_power, 2) if pv_L3_power is not None else None
+                self._dbusservice["/Ac/L3/Current"] = round(pv_L3_current, 2) if pv_L3_current is not None else None
+                self._dbusservice["/Ac/L3/Voltage"] = round(pv_L3_voltage, 2) if pv_L3_voltage is not None else None
+                self._dbusservice["/Ac/L3/Frequency"] = round(pv_L3_frequency, 2) if pv_L3_frequency is not None else None
+                self._dbusservice["/Ac/L3/Energy/Forward"] = round(pv_L3_forward, 2) if pv_L3_forward is not None else None
 
-            logging.debug(
-                "PV: {:.1f} W - {:.1f} V - {:.1f} A".format(
-                    pv_power, pv_voltage, pv_current
-                )
-            )
+            logging.debug("PV: {:.1f} W - {:.1f} V - {:.1f} A".format(pv_power, pv_voltage, pv_current))
             if pv_L1_power:
-                logging.debug(
-                    "|- L1: {:.1f} W - {:.1f} V - {:.1f} A".format(
-                        pv_L1_power, pv_L1_voltage, pv_L1_current
-                    )
-                )
+                logging.debug("|- L1: {:.1f} W - {:.1f} V - {:.1f} A".format(pv_L1_power, pv_L1_voltage, pv_L1_current))
             if pv_L2_power:
-                logging.debug(
-                    "|- L2: {:.1f} W - {:.1f} V - {:.1f} A".format(
-                        pv_L2_power, pv_L2_voltage, pv_L2_current
-                    )
-                )
+                logging.debug("|- L2: {:.1f} W - {:.1f} V - {:.1f} A".format(pv_L2_power, pv_L2_voltage, pv_L2_current))
             if pv_L3_power:
-                logging.debug(
-                    "|- L3: {:.1f} W - {:.1f} V - {:.1f} A".format(
-                        pv_L3_power, pv_L3_voltage, pv_L3_current
-                    )
-                )
+                logging.debug("|- L3: {:.1f} W - {:.1f} V - {:.1f} A".format(pv_L3_power, pv_L3_voltage, pv_L3_current))
 
             # is only displayed for Fronius inverters (product ID 0xA142) in GUI but displayed in VRM portal
             # if power above 10 W, set status code to 7 (running)
@@ -498,10 +353,7 @@ class DbusMqttPvService:
 
         # quit driver if timeout is exceeded
         if timeout != 0 and (now - last_changed) > timeout:
-            logging.error(
-                "Driver stopped. Timeout of %i seconds exceeded, since no new MQTT message was received in this time."
-                % timeout
-            )
+            logging.error("Driver stopped. Timeout of %i seconds exceeded, since no new MQTT message was received in this time." % timeout)
             sys.exit()
 
         # increment UpdateIndex - to show that new data is available
@@ -527,12 +379,7 @@ def main():
     DBusGMainLoop(set_as_default=True)
 
     # MQTT setup
-    client = mqtt.Client(
-        "MqttPv_"
-        + get_vrm_portal_id()
-        + "_"
-        + str(config["DEFAULT"]["device_instance"])
-    )
+    client = mqtt.Client("MqttPv_" + get_vrm_portal_id() + "_" + str(config["DEFAULT"]["device_instance"]))
     client.on_disconnect = on_disconnect
     client.on_connect = on_connect
     client.on_message = on_message
@@ -589,9 +436,7 @@ def main():
         if i % 12 != 0 or i == 0:
             logging.info("Waiting 5 seconds for receiving first data...")
         else:
-            logging.warning(
-                "Waiting since %s seconds for receiving first data..." % str(i * 5)
-            )
+            logging.warning("Waiting since %s seconds for receiving first data..." % str(i * 5))
 
         # check if timeout was exceeded
         if timeout != 0 and timeout <= (i * 5):
@@ -662,16 +507,13 @@ def main():
     )
 
     DbusMqttPvService(
-        servicename="com.victronenergy.pvinverter.mqtt_pv_"
-        + str(config["DEFAULT"]["device_instance"]),
+        servicename="com.victronenergy.pvinverter.mqtt_pv_" + str(config["DEFAULT"]["device_instance"]),
         deviceinstance=int(config["DEFAULT"]["device_instance"]),
         customname=config["DEFAULT"]["device_name"],
         paths=paths_dbus,
     )
 
-    logging.info(
-        "Connected to dbus and switching over to GLib.MainLoop() (= event based)"
-    )
+    logging.info("Connected to dbus and switching over to GLib.MainLoop() (= event based)")
     mainloop = GLib.MainLoop()
     mainloop.run()
 

--- a/dbus-mqtt-pv/dbus-mqtt-pv.py
+++ b/dbus-mqtt-pv/dbus-mqtt-pv.py
@@ -24,11 +24,17 @@ try:
         config = configparser.ConfigParser()
         config.read(config_file)
         if config["MQTT"]["broker_address"] == "IP_ADDR_OR_FQDN":
-            print('ERROR:The "config.ini" is using invalid default values like IP_ADDR_OR_FQDN. The driver restarts in 60 seconds.')
+            print(
+                'ERROR:The "config.ini" is using invalid default values like IP_ADDR_OR_FQDN. The driver restarts in 60 seconds.'
+            )
             sleep(60)
             sys.exit()
     else:
-        print('ERROR:The "' + config_file + '" is not found. Did you copy or rename the "config.sample.ini" to "config.ini"? The driver restarts in 60 seconds.')
+        print(
+            'ERROR:The "'
+            + config_file
+            + '" is not found. Did you copy or rename the "config.sample.ini" to "config.ini"? The driver restarts in 60 seconds.'
+        )
         sleep(60)
         sys.exit()
 
@@ -36,7 +42,9 @@ except Exception:
     exception_type, exception_object, exception_traceback = sys.exc_info()
     file = exception_traceback.tb_frame.f_code.co_filename
     line = exception_traceback.tb_lineno
-    print(f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}")
+    print(
+        f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}"
+    )
     print("ERROR:The driver restarts in 60 seconds.")
     sleep(60)
     sys.exit()
@@ -101,17 +109,21 @@ def on_disconnect(client, userdata, rc):
     global connected
     logging.warning("MQTT client: Got disconnected")
     if rc != 0:
-        logging.warning("MQTT client: Unexpected MQTT disconnection. Will auto-reconnect")
+        logging.warning(
+            "MQTT client: Unexpected MQTT disconnection. Will auto-reconnect"
+        )
     else:
         logging.warning("MQTT client: rc value:" + str(rc))
 
     while connected == 0:
         try:
-            logging.warning(f"MQTT client: Trying to reconnect to broker {config['MQTT']['broker_address']} on port {config['MQTT']['broker_port']}")
-            client.connect(host=config["MQTT"]["broker_address"], port=int(config["MQTT"]["broker_port"]))
+            logging.warning("MQTT client: Trying to reconnect")
+            client.connect(config["MQTT"]["broker_address"])
             connected = 1
         except Exception as err:
-            logging.error(f"MQTT client: Error in retrying to connect with broker ({config['MQTT']['broker_address']}:{config['MQTT']['broker_port']}): {err}")
+            logging.error(
+                f"MQTT client: Error in retrying to connect with broker ({config['MQTT']['broker_address']}:{config['MQTT']['broker_port']}): {err}"
+            )
             logging.error("MQTT client: Retrying in 15 seconds")
             connected = 0
             sleep(15)
@@ -135,6 +147,9 @@ def on_message(client, userdata, msg):
         global pv_L2_power, pv_L2_current, pv_L2_voltage, pv_L2_frequency, pv_L2_forward
         global pv_L3_power, pv_L3_current, pv_L3_voltage, pv_L3_frequency, pv_L3_forward
 
+        # Check if Shelly mode is enabled
+        shelly_mode = config.get('DEFAULT', 'shelly', fallback='false').lower() == 'true'
+
         # get JSON from topic
         if msg.topic == config["MQTT"]["topic"]:
             if msg.payload != "" and msg.payload != b"":
@@ -142,49 +157,150 @@ def on_message(client, userdata, msg):
 
                 last_changed = int(time())
 
-                if "pv" in jsonpayload:
-                    if isinstance(jsonpayload["pv"], dict) and "power" in jsonpayload["pv"]:
-                        pv_power = float(jsonpayload["pv"]["power"])
-                        pv_current = float(jsonpayload["pv"]["current"]) if "current" in jsonpayload["pv"] else pv_power / float(config["DEFAULT"]["voltage"])
-                        pv_voltage = float(jsonpayload["pv"]["voltage"]) if "voltage" in jsonpayload["pv"] else float(config["DEFAULT"]["voltage"])
-                        if "energy_forward" in jsonpayload["pv"]:
-                            pv_forward = float(jsonpayload["pv"]["energy_forward"])
+                # Shelly-specific payload parsing
+                if shelly_mode:
+                    if "apower" in jsonpayload:
+                        pv_power = float(jsonpayload.get("apower", 0))
+                        
+                        pv_current = float(jsonpayload.get("current", pv_power / float(config["DEFAULT"]["voltage"])))
+                        pv_voltage = float(jsonpayload.get("voltage", float(config["DEFAULT"]["voltage"])))
+                        pv_forward = float(jsonpayload.get("aenergy", {}).get("total", 0)) / 1000 if "aenergy" in jsonpayload else None
+                        
+                        pv_L1_power = pv_power
+                        pv_L1_current = pv_current
+                        pv_L1_voltage = pv_voltage
+                        pv_L1_frequency = float(jsonpayload.get("freq", float(config["DEFAULT"]["frequency"])))
+                        pv_L1_forward = pv_forward
 
-                        # check if L1 and L1 -> power exists
-                        if "L1" in jsonpayload["pv"] and "power" in jsonpayload["pv"]["L1"]:
-                            pv_L1_power = float(jsonpayload["pv"]["L1"]["power"])
-                            pv_L1_current = float(jsonpayload["pv"]["L1"]["current"]) if "current" in jsonpayload["pv"]["L1"] else pv_L1_power / float(config["DEFAULT"]["voltage"])
-                            pv_L1_voltage = float(jsonpayload["pv"]["L1"]["voltage"]) if "voltage" in jsonpayload["pv"]["L1"] else float(config["DEFAULT"]["voltage"])
-                            pv_L1_frequency = float(jsonpayload["pv"]["L1"]["frequency"]) if "frequency" in jsonpayload["pv"]["L1"] else float(config["DEFAULT"]["frequency"])
-                            if "energy_forward" in jsonpayload["pv"]["L1"]:
-                                pv_L1_forward = float(jsonpayload["pv"]["L1"]["energy_forward"])
+                        # Clear multi-phase values
+                        pv_L2_power = None
+                        pv_L2_current = None
+                        pv_L2_voltage = None
+                        pv_L2_frequency = None
+                        pv_L2_forward = None
 
-                        # check if L2 and L2 -> power exists
-                        if "L2" in jsonpayload["pv"] and "power" in jsonpayload["pv"]["L2"]:
-                            pv_L2_power = float(jsonpayload["pv"]["L2"]["power"])
-                            pv_L2_current = float(jsonpayload["pv"]["L2"]["current"]) if "current" in jsonpayload["pv"]["L2"] else pv_L2_power / float(config["DEFAULT"]["voltage"])
-                            pv_L2_voltage = float(jsonpayload["pv"]["L2"]["voltage"]) if "voltage" in jsonpayload["pv"]["L2"] else float(config["DEFAULT"]["voltage"])
-                            pv_L2_frequency = float(jsonpayload["pv"]["L2"]["frequency"]) if "frequency" in jsonpayload["pv"]["L2"] else float(config["DEFAULT"]["frequency"])
-                            if "energy_forward" in jsonpayload["pv"]["L2"]:
-                                pv_L2_forward = float(jsonpayload["pv"]["L2"]["energy_forward"])
+                        pv_L3_power = None
+                        pv_L3_current = None
+                        pv_L3_voltage = None
+                        pv_L3_frequency = None
+                        pv_L3_forward = None
 
-                        # check if L3 and L3 -> power exists
-                        if "L3" in jsonpayload["pv"] and "power" in jsonpayload["pv"]["L3"]:
-                            pv_L3_power = float(jsonpayload["pv"]["L3"]["power"])
-                            pv_L3_current = float(jsonpayload["pv"]["L3"]["current"]) if "current" in jsonpayload["pv"]["L3"] else pv_L3_power / float(config["DEFAULT"]["voltage"])
-                            pv_L3_voltage = float(jsonpayload["pv"]["L3"]["voltage"]) if "voltage" in jsonpayload["pv"]["L3"] else float(config["DEFAULT"]["voltage"])
-                            pv_L3_frequency = float(jsonpayload["pv"]["L3"]["frequency"]) if "frequency" in jsonpayload["pv"]["L3"] else float(config["DEFAULT"]["frequency"])
-                            if "energy_forward" in jsonpayload["pv"]["L3"]:
-                                pv_L3_forward = float(jsonpayload["pv"]["L3"]["energy_forward"])
                     else:
-                        logging.error('Received JSON MQTT message does not include a power object in the pv object. Expected at least: {"pv": {"power": 0.0}}')
-                        logging.debug("MQTT payload: " + str(msg.payload)[1:])
+                        logging.error('Received Shelly JSON MQTT message does not include apower. Expected at least: {"apower": 0.0}')
+                
                 else:
-                    logging.error('Received JSON MQTT message does not include a pv object. Expected at least: {"pv": {"power": 0.0}}')
-                    logging.debug("MQTT payload: " + str(msg.payload)[1:])
+                    if "pv" in jsonpayload:
+                        if (
+                            isinstance(jsonpayload["pv"], dict)
+                            and "power" in jsonpayload["pv"]
+                        ):
+                            pv_power = float(jsonpayload["pv"]["power"])
+                            pv_current = (
+                                float(jsonpayload["pv"]["current"])
+                                if "current" in jsonpayload["pv"]
+                                else pv_power / float(config["DEFAULT"]["voltage"])
+                            )
+                            pv_voltage = (
+                                float(jsonpayload["pv"]["voltage"])
+                                if "voltage" in jsonpayload["pv"]
+                                else float(config["DEFAULT"]["voltage"])
+                            )
+                            if "energy_forward" in jsonpayload["pv"]:
+                                pv_forward = float(jsonpayload["pv"]["energy_forward"])
+
+                            # check if L1 and L1 -> power exists
+                            if (
+                                "L1" in jsonpayload["pv"]
+                                and "power" in jsonpayload["pv"]["L1"]
+                            ):
+                                pv_L1_power = float(jsonpayload["pv"]["L1"]["power"])
+                                pv_L1_current = (
+                                    float(jsonpayload["pv"]["L1"]["current"])
+                                    if "current" in jsonpayload["pv"]["L1"]
+                                    else pv_L1_power / float(config["DEFAULT"]["voltage"])
+                                )
+                                pv_L1_voltage = (
+                                    float(jsonpayload["pv"]["L1"]["voltage"])
+                                    if "voltage" in jsonpayload["pv"]["L1"]
+                                    else float(config["DEFAULT"]["voltage"])
+                                )
+                                pv_L1_frequency = (
+                                    float(jsonpayload["pv"]["L1"]["frequency"])
+                                    if "frequency" in jsonpayload["pv"]["L1"]
+                                    else float(config["DEFAULT"]["frequency"])
+                                )
+                                if "energy_forward" in jsonpayload["pv"]["L1"]:
+                                    pv_L1_forward = float(
+                                        jsonpayload["pv"]["L1"]["energy_forward"]
+                                    )
+
+                            # check if L2 and L2 -> power exists
+                            if (
+                                "L2" in jsonpayload["pv"]
+                                and "power" in jsonpayload["pv"]["L2"]
+                            ):
+                                pv_L2_power = float(jsonpayload["pv"]["L2"]["power"])
+                                pv_L2_current = (
+                                    float(jsonpayload["pv"]["L2"]["current"])
+                                    if "current" in jsonpayload["pv"]["L2"]
+                                    else pv_L2_power / float(config["DEFAULT"]["voltage"])
+                                )
+                                pv_L2_voltage = (
+                                    float(jsonpayload["pv"]["L2"]["voltage"])
+                                    if "voltage" in jsonpayload["pv"]["L2"]
+                                    else float(config["DEFAULT"]["voltage"])
+                                )
+                                pv_L2_frequency = (
+                                    float(jsonpayload["pv"]["L2"]["frequency"])
+                                    if "frequency" in jsonpayload["pv"]["L2"]
+                                    else float(config["DEFAULT"]["frequency"])
+                                )
+                                if "energy_forward" in jsonpayload["pv"]["L2"]:
+                                    pv_L2_forward = float(
+                                        jsonpayload["pv"]["L2"]["energy_forward"]
+                                    )
+
+                            # check if L3 and L3 -> power exists
+                            if (
+                                "L3" in jsonpayload["pv"]
+                                and "power" in jsonpayload["pv"]["L3"]
+                            ):
+                                pv_L3_power = float(jsonpayload["pv"]["L3"]["power"])
+                                pv_L3_current = (
+                                    float(jsonpayload["pv"]["L3"]["current"])
+                                    if "current" in jsonpayload["pv"]["L3"]
+                                    else pv_L3_power / float(config["DEFAULT"]["voltage"])
+                                )
+                                pv_L3_voltage = (
+                                    float(jsonpayload["pv"]["L3"]["voltage"])
+                                    if "voltage" in jsonpayload["pv"]["L3"]
+                                    else float(config["DEFAULT"]["voltage"])
+                                )
+                                pv_L3_frequency = (
+                                    float(jsonpayload["pv"]["L3"]["frequency"])
+                                    if "frequency" in jsonpayload["pv"]["L3"]
+                                    else float(config["DEFAULT"]["frequency"])
+                                )
+                                if "energy_forward" in jsonpayload["pv"]["L3"]:
+                                    pv_L3_forward = float(
+                                        jsonpayload["pv"]["L3"]["energy_forward"]
+                                    )
+                        else:
+                            logging.error(
+                                'Received JSON MQTT message does not include a power object in the pv object. Expected at least: {"pv": {"power": 0.0}"}'
+                            )
+                            logging.debug("MQTT payload: " + str(msg.payload)[1:])
+
+                    else:
+                        logging.error(
+                            'Received JSON MQTT message does not include a pv object. Expected at least: {"pv": {"power": 0.0}"}'
+                        )
+                        logging.debug("MQTT payload: " + str(msg.payload)[1:])
 
             else:
-                logging.warning("Received JSON MQTT message was empty and therefore it was ignored")
+                logging.warning(
+                    "Received JSON MQTT message was empty and therefore it was ignored"
+                )
                 logging.debug("MQTT payload: " + str(msg.payload)[1:])
 
     except TypeError as e:
@@ -199,7 +315,9 @@ def on_message(client, userdata, msg):
         exception_type, exception_object, exception_traceback = sys.exc_info()
         file = exception_traceback.tb_frame.f_code.co_filename
         line = exception_traceback.tb_lineno
-        logging.error(f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}")
+        logging.error(
+            f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}"
+        )
         logging.debug("MQTT payload: " + str(msg.payload)[1:])
 
 
@@ -263,46 +381,108 @@ class DbusMqttPvService:
 
         if last_changed != last_updated:
 
-            self._dbusservice["/Ac/Power"] = round(pv_power, 2) if pv_power is not None else None
-            self._dbusservice["/Ac/Current"] = round(pv_current, 2) if pv_current is not None else None
-            self._dbusservice["/Ac/Voltage"] = round(pv_voltage, 2) if pv_voltage is not None else None
-            self._dbusservice["/Ac/Energy/Forward"] = round(pv_forward, 2) if pv_forward is not None else None
+            self._dbusservice["/Ac/Power"] = (
+                round(pv_power, 2) if pv_power is not None else None
+            )
+            self._dbusservice["/Ac/Current"] = (
+                round(pv_current, 2) if pv_current is not None else None
+            )
+            self._dbusservice["/Ac/Voltage"] = (
+                round(pv_voltage, 2) if pv_voltage is not None else None
+            )
+            self._dbusservice["/Ac/Energy/Forward"] = (
+                round(pv_forward, 2) if pv_forward is not None else None
+            )
 
             if pv_L1_power is not None:
-                self._dbusservice["/Ac/L1/Power"] = round(pv_L1_power, 2) if pv_L1_power is not None else None
-                self._dbusservice["/Ac/L1/Current"] = round(pv_L1_current, 2) if pv_L1_current is not None else None
-                self._dbusservice["/Ac/L1/Voltage"] = round(pv_L1_voltage, 2) if pv_L1_voltage is not None else None
-                self._dbusservice["/Ac/L1/Frequency"] = round(pv_L1_frequency, 2) if pv_L1_frequency is not None else None
-                self._dbusservice["/Ac/L1/Energy/Forward"] = round(pv_L1_forward, 2) if pv_L1_forward is not None else None
+                self._dbusservice["/Ac/L1/Power"] = (
+                    round(pv_L1_power, 2) if pv_L1_power is not None else None
+                )
+                self._dbusservice["/Ac/L1/Current"] = (
+                    round(pv_L1_current, 2) if pv_L1_current is not None else None
+                )
+                self._dbusservice["/Ac/L1/Voltage"] = (
+                    round(pv_L1_voltage, 2) if pv_L1_voltage is not None else None
+                )
+                self._dbusservice["/Ac/L1/Frequency"] = (
+                    round(pv_L1_frequency, 2) if pv_L1_frequency is not None else None
+                )
+                self._dbusservice["/Ac/L1/Energy/Forward"] = (
+                    round(pv_L1_forward, 2) if pv_L1_forward is not None else None
+                )
             # at least one phase is needed to work properly
             elif pv_L2_power is None and pv_L3_power is None:
-                self._dbusservice["/Ac/L1/Power"] = round(pv_power, 2) if pv_power is not None else None
-                self._dbusservice["/Ac/L1/Current"] = round(pv_current, 2) if pv_current is not None else None
-                self._dbusservice["/Ac/L1/Voltage"] = round(pv_voltage, 2) if pv_voltage is not None else None
+                self._dbusservice["/Ac/L1/Power"] = (
+                    round(pv_power, 2) if pv_power is not None else None
+                )
+                self._dbusservice["/Ac/L1/Current"] = (
+                    round(pv_current, 2) if pv_current is not None else None
+                )
+                self._dbusservice["/Ac/L1/Voltage"] = (
+                    round(pv_voltage, 2) if pv_voltage is not None else None
+                )
                 self._dbusservice["/Ac/L1/Frequency"] = None
-                self._dbusservice["/Ac/L1/Energy/Forward"] = round(pv_forward, 2) if pv_forward is not None else None
+                self._dbusservice["/Ac/L1/Energy/Forward"] = (
+                    round(pv_forward, 2) if pv_forward is not None else None
+                )
 
             if pv_L2_power is not None:
-                self._dbusservice["/Ac/L2/Power"] = round(pv_L2_power, 2) if pv_L2_power is not None else None
-                self._dbusservice["/Ac/L2/Current"] = round(pv_L2_current, 2) if pv_L2_current is not None else None
-                self._dbusservice["/Ac/L2/Voltage"] = round(pv_L2_voltage, 2) if pv_L2_voltage is not None else None
-                self._dbusservice["/Ac/L2/Frequency"] = round(pv_L2_frequency, 2) if pv_L2_frequency is not None else None
-                self._dbusservice["/Ac/L2/Energy/Forward"] = round(pv_L2_forward, 2) if pv_L2_forward is not None else None
+                self._dbusservice["/Ac/L2/Power"] = (
+                    round(pv_L2_power, 2) if pv_L2_power is not None else None
+                )
+                self._dbusservice["/Ac/L2/Current"] = (
+                    round(pv_L2_current, 2) if pv_L2_current is not None else None
+                )
+                self._dbusservice["/Ac/L2/Voltage"] = (
+                    round(pv_L2_voltage, 2) if pv_L2_voltage is not None else None
+                )
+                self._dbusservice["/Ac/L2/Frequency"] = (
+                    round(pv_L2_frequency, 2) if pv_L2_frequency is not None else None
+                )
+                self._dbusservice["/Ac/L2/Energy/Forward"] = (
+                    round(pv_L2_forward, 2) if pv_L2_forward is not None else None
+                )
 
             if pv_L3_power is not None:
-                self._dbusservice["/Ac/L3/Power"] = round(pv_L3_power, 2) if pv_L3_power is not None else None
-                self._dbusservice["/Ac/L3/Current"] = round(pv_L3_current, 2) if pv_L3_current is not None else None
-                self._dbusservice["/Ac/L3/Voltage"] = round(pv_L3_voltage, 2) if pv_L3_voltage is not None else None
-                self._dbusservice["/Ac/L3/Frequency"] = round(pv_L3_frequency, 2) if pv_L3_frequency is not None else None
-                self._dbusservice["/Ac/L3/Energy/Forward"] = round(pv_L3_forward, 2) if pv_L3_forward is not None else None
+                self._dbusservice["/Ac/L3/Power"] = (
+                    round(pv_L3_power, 2) if pv_L3_power is not None else None
+                )
+                self._dbusservice["/Ac/L3/Current"] = (
+                    round(pv_L3_current, 2) if pv_L3_current is not None else None
+                )
+                self._dbusservice["/Ac/L3/Voltage"] = (
+                    round(pv_L3_voltage, 2) if pv_L3_voltage is not None else None
+                )
+                self._dbusservice["/Ac/L3/Frequency"] = (
+                    round(pv_L3_frequency, 2) if pv_L3_frequency is not None else None
+                )
+                self._dbusservice["/Ac/L3/Energy/Forward"] = (
+                    round(pv_L3_forward, 2) if pv_L3_forward is not None else None
+                )
 
-            logging.debug("PV: {:.1f} W - {:.1f} V - {:.1f} A".format(pv_power, pv_voltage, pv_current))
+            logging.debug(
+                "PV: {:.1f} W - {:.1f} V - {:.1f} A".format(
+                    pv_power, pv_voltage, pv_current
+                )
+            )
             if pv_L1_power:
-                logging.debug("|- L1: {:.1f} W - {:.1f} V - {:.1f} A".format(pv_L1_power, pv_L1_voltage, pv_L1_current))
+                logging.debug(
+                    "|- L1: {:.1f} W - {:.1f} V - {:.1f} A".format(
+                        pv_L1_power, pv_L1_voltage, pv_L1_current
+                    )
+                )
             if pv_L2_power:
-                logging.debug("|- L2: {:.1f} W - {:.1f} V - {:.1f} A".format(pv_L2_power, pv_L2_voltage, pv_L2_current))
+                logging.debug(
+                    "|- L2: {:.1f} W - {:.1f} V - {:.1f} A".format(
+                        pv_L2_power, pv_L2_voltage, pv_L2_current
+                    )
+                )
             if pv_L3_power:
-                logging.debug("|- L3: {:.1f} W - {:.1f} V - {:.1f} A".format(pv_L3_power, pv_L3_voltage, pv_L3_current))
+                logging.debug(
+                    "|- L3: {:.1f} W - {:.1f} V - {:.1f} A".format(
+                        pv_L3_power, pv_L3_voltage, pv_L3_current
+                    )
+                )
 
             # is only displayed for Fronius inverters (product ID 0xA142) in GUI but displayed in VRM portal
             # if power above 10 W, set status code to 7 (running)
@@ -318,7 +498,10 @@ class DbusMqttPvService:
 
         # quit driver if timeout is exceeded
         if timeout != 0 and (now - last_changed) > timeout:
-            logging.error("Driver stopped. Timeout of %i seconds exceeded, since no new MQTT message was received in this time." % timeout)
+            logging.error(
+                "Driver stopped. Timeout of %i seconds exceeded, since no new MQTT message was received in this time."
+                % timeout
+            )
             sys.exit()
 
         # increment UpdateIndex - to show that new data is available
@@ -344,7 +527,12 @@ def main():
     DBusGMainLoop(set_as_default=True)
 
     # MQTT setup
-    client = mqtt.Client("MqttPv_" + get_vrm_portal_id() + "_" + str(config["DEFAULT"]["device_instance"]))
+    client = mqtt.Client(
+        "MqttPv_"
+        + get_vrm_portal_id()
+        + "_"
+        + str(config["DEFAULT"]["device_instance"])
+    )
     client.on_disconnect = on_disconnect
     client.on_connect = on_connect
     client.on_message = on_message
@@ -353,24 +541,46 @@ def main():
     if "tls_enabled" in config["MQTT"] and config["MQTT"]["tls_enabled"] == "1":
         logging.info("MQTT client: TLS is enabled")
 
-        if "tls_path_to_ca" in config["MQTT"] and config["MQTT"]["tls_path_to_ca"] != "":
-            logging.info('MQTT client: TLS: custom ca "%s" used' % config["MQTT"]["tls_path_to_ca"])
+        if (
+            "tls_path_to_ca" in config["MQTT"]
+            and config["MQTT"]["tls_path_to_ca"] != ""
+        ):
+            logging.info(
+                'MQTT client: TLS: custom ca "%s" used'
+                % config["MQTT"]["tls_path_to_ca"]
+            )
             client.tls_set(config["MQTT"]["tls_path_to_ca"], tls_version=2)
         else:
             client.tls_set(tls_version=2)
 
         if "tls_insecure" in config["MQTT"] and config["MQTT"]["tls_insecure"] != "":
-            logging.info("MQTT client: TLS certificate server hostname verification disabled")
+            logging.info(
+                "MQTT client: TLS certificate server hostname verification disabled"
+            )
             client.tls_insecure_set(True)
 
     # check if username and password are set
-    if "username" in config["MQTT"] and "password" in config["MQTT"] and config["MQTT"]["username"] != "" and config["MQTT"]["password"] != "":
-        logging.info('MQTT client: Using username "%s" and password to connect' % config["MQTT"]["username"])
-        client.username_pw_set(username=config["MQTT"]["username"], password=config["MQTT"]["password"])
+    if (
+        "username" in config["MQTT"]
+        and "password" in config["MQTT"]
+        and config["MQTT"]["username"] != ""
+        and config["MQTT"]["password"] != ""
+    ):
+        logging.info(
+            'MQTT client: Using username "%s" and password to connect'
+            % config["MQTT"]["username"]
+        )
+        client.username_pw_set(
+            username=config["MQTT"]["username"], password=config["MQTT"]["password"]
+        )
 
     # connect to broker
-    logging.info(f"MQTT client: Connecting to broker {config['MQTT']['broker_address']} on port {config['MQTT']['broker_port']}")
-    client.connect(host=config["MQTT"]["broker_address"], port=int(config["MQTT"]["broker_port"]))
+    logging.info(
+        f"MQTT client: Connecting to broker {config['MQTT']['broker_address']} on port {config['MQTT']['broker_port']}"
+    )
+    client.connect(
+        host=config["MQTT"]["broker_address"], port=int(config["MQTT"]["broker_port"])
+    )
     client.loop_start()
 
     # wait to receive first data, else the JSON is empty and phase setup won't work
@@ -379,7 +589,9 @@ def main():
         if i % 12 != 0 or i == 0:
             logging.info("Waiting 5 seconds for receiving first data...")
         else:
-            logging.warning("Waiting since %s seconds for receiving first data..." % str(i * 5))
+            logging.warning(
+                "Waiting since %s seconds for receiving first data..." % str(i * 5)
+            )
 
         # check if timeout was exceeded
         if timeout != 0 and timeout <= (i * 5):
@@ -450,13 +662,16 @@ def main():
     )
 
     DbusMqttPvService(
-        servicename="com.victronenergy.pvinverter.mqtt_pv_" + str(config["DEFAULT"]["device_instance"]),
+        servicename="com.victronenergy.pvinverter.mqtt_pv_"
+        + str(config["DEFAULT"]["device_instance"]),
         deviceinstance=int(config["DEFAULT"]["device_instance"]),
         customname=config["DEFAULT"]["device_name"],
         paths=paths_dbus,
     )
 
-    logging.info("Connected to dbus and switching over to GLib.MainLoop() (= event based)")
+    logging.info(
+        "Connected to dbus and switching over to GLib.MainLoop() (= event based)"
+    )
     mainloop = GLib.MainLoop()
     mainloop.run()
 

--- a/dbus-mqtt-pv/restart.sh
+++ b/dbus-mqtt-pv/restart.sh
@@ -2,4 +2,10 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SERVICE_NAME=$(basename $SCRIPT_DIR)
 
-kill $(pgrep -f "python $SCRIPT_DIR/$SERVICE_NAME.py")
+pid=$(pgrep -f "python $SCRIPT_DIR/$SERVICE_NAME.py")
+if [ -n "$pid" ]; then
+    kill $pid
+    echo "** Driver restarted **"
+else
+    echo "** Driver is not running **"
+fi

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+
+driver_path="/data/etc"
+driver_name="dbus-mqtt-pv"
+
+echo ""
+echo ""
+
+# fetch version numbers for different versions
+echo -n "Fetch current version numbers..."
+
+# latest release
+latest_release_stable=$(curl -s https://api.github.com/repos/mr-manuel/venus-os_${driver_name}/releases/latest | grep "tag_name" | cut -d : -f 2,3 | tr -d "\ " | tr -d \" | tr -d \,)
+
+# nightly build
+latest_release_nightly=$(curl -s https://raw.githubusercontent.com/mr-manuel/venus-os_${driver_name}/master/${driver_name}/${driver_name}.py | grep FirmwareVersion | awk -F'"' '{print $4}')
+
+
+echo
+PS3=$'\nSelect which version you want to install and enter the corresponding number: '
+
+# create list of versions
+version_list=(
+    "latest release \"$latest_release_stable\""
+    "nightly build \"v$latest_release_nightly\""
+    "quit"
+)
+
+select version in "${version_list[@]}"
+do
+    case $version in
+        "latest release \"$latest_release_stable\"")
+            break
+            ;;
+        "nightly build \"v$latest_release_nightly\"")
+            break
+            ;;
+        "quit")
+            exit 0
+            ;;
+        *)
+            echo "> Invalid option: $REPLY. Please enter a number!"
+            ;;
+    esac
+done
+
+echo "> Selected: $version"
+echo ""
+
+
+# Which driver instance do you want to install?
+echo "Which driver instance do you want to install/update?"
+while true; do
+    read -p "Enter the driver instance number you want to install/update. If you don't know just press enter [1]: " driver_instance
+    if [[ -z "$driver_instance" || ( "$driver_instance" =~ ^[0-9]+$ && "$driver_instance" -ge 1 && "$driver_instance" -le 99 ) ]]; then
+        break
+    else
+        echo "Invalid input. Please enter a number between 1 and 255 or press enter."
+    fi
+done
+
+if [ -n "$driver_instance" ] && [ "$driver_instance" != "1" ]; then
+    driver_name_instance="${driver_name}-${driver_instance}"
+else
+    driver_name_instance=${driver_name}
+fi
+
+
+echo ""
+if [ -d ${driver_path}/${driver_name_instance} ]; then
+    echo "Updating driver '$driver_name' as '$driver_name_instance'..."
+else
+    echo "Installing driver '$driver_name' as '$driver_name_instance'..."
+fi
+
+
+# change to temp folder
+cd /tmp
+
+
+# download driver
+echo ""
+echo "Downloading driver..."
+
+
+## latest release
+if [ "$version" = "latest release \"$latest_release_stable\"" ]; then
+    # download latest release
+    url=$(curl -s https://api.github.com/repos/mr-manuel/venus-os_${driver_name}/releases/latest | grep "zipball_url" | sed -n 's/.*"zipball_url": "\([^"]*\)".*/\1/p')
+fi
+
+## nightly build
+if [ "$version" = "nightly build \"v$latest_release_nightly\"" ]; then
+    # download nightly build
+    url="https://github.com/mr-manuel/venus-os_${driver_name}/archive/refs/heads/master.zip"
+fi
+
+echo "Downloading from: $url"
+wget -O /tmp/venus-os_${driver_name}.zip "$url"
+
+# check if download was successful
+if [ ! -f /tmp/venus-os_${driver_name}.zip ]; then
+    echo ""
+    echo "Download failed. Exiting..."
+    exit 1
+fi
+
+
+# If updating: cleanup old folder
+if [ -d /tmp/venus-os_${driver_name}-master ]; then
+    rm -rf /tmp/venus-os_${driver_name}-master
+fi
+
+
+# unzip folder
+echo "Unzipping driver..."
+unzip venus-os_${driver_name}.zip
+
+# Find and rename the extracted folder to be always the same
+extracted_folder=$(find /tmp/ -maxdepth 1 -type d -name "*${driver_name}-*")
+
+# Desired folder name
+desired_folder="/tmp/venus-os_${driver_name}-master"
+
+# Check if the extracted folder exists and does not already have the desired name
+if [ -n "$extracted_folder" ]; then
+    if [ "$extracted_folder" != "$desired_folder" ]; then
+        mv "$extracted_folder" "$desired_folder"
+    else
+        echo "Folder already has the desired name: $desired_folder"
+    fi
+else
+    echo "Error: Could not find extracted folder. Exiting..."
+    # exit 1
+fi
+
+
+# If updating: backup existing config file
+if [ -f ${driver_path}/${driver_name_instance}/config.ini ]; then
+    echo ""
+    echo "Backing up existing config file..."
+    mv ${driver_path}/${driver_name_instance}/config.ini ${driver_path}/${driver_name_instance}_config.ini
+fi
+
+
+# If updating: cleanup existing driver
+if [ -d ${driver_path}/${driver_name_instance} ]; then
+    echo ""
+    echo "Cleaning up existing driver..."
+    rm -rf ${driver_path}/${driver_name_instance}
+fi
+
+
+# copy files
+echo ""
+echo "Copying new driver files..."
+cp -R /tmp/venus-os_${driver_name}-master/${driver_name}/ ${driver_path}/${driver_name_instance}/
+
+# remove temp files
+echo ""
+echo "Cleaning up temp files..."
+rm -rf /tmp/venus-os_${driver_name}.zip
+rm -rf /tmp/venus-os_${driver_name}-master
+
+
+# check if driver_name is no equal to driver_name_instance
+if [ "$driver_name" != "$driver_name_instance" ]; then
+    echo ""
+    echo "Renaming internal driver files..."
+    # rename the driver_name.py file to driver_name_instance.py
+    mv ${driver_path}/${driver_name_instance}/${driver_name}.py ${driver_path}/${driver_name_instance}/${driver_name_instance}.py
+    # rename the driver_name in the run file to driver_name_instance
+    sed -i 's:'${driver_name}':'${driver_name_instance}':g' ${driver_path}/${driver_name_instance}/service/run
+    # rename the driver_name in the log run file to driver_name_instance
+    sed -i 's:'${driver_name}':'${driver_name_instance}':g' ${driver_path}/${driver_name_instance}/service/log/run
+
+    # add device_instance to the end of the line where device_name is found in the config sample file
+    sed -i '/device_name/s/$/ '${driver_instance}'/' ${driver_path}/${driver_name_instance}/config.sample.ini
+
+    # change the device_instance from 100 to 100 + device_instance in the config sample file
+    config_file_device_instance=$(grep 'device_instance = ' ${driver_path}/${driver_name_instance}/config.sample.ini | awk -F' = ' '{print $2}')
+    new_device_instance=$((config_file_device_instance + driver_instance))
+    sed -i 's/device_instance = 100/device_instance = '${new_device_instance}'/' ${driver_path}/${driver_name_instance}/config.sample.ini
+
+fi
+
+
+# If updating: restore existing config file
+if [ -f ${driver_path}/${driver_name_instance}_config.ini ]; then
+    echo ""
+    echo "Restoring existing config file..."
+    mv ${driver_path}/${driver_name_instance}_config.ini ${driver_path}/${driver_name_instance}/config.ini
+fi
+
+
+# set permissions for files
+echo ""
+echo "Setting permissions for files..."
+chmod 755 ${driver_path}/${driver_name_instance}/${driver_name_instance}.py
+chmod 755 ${driver_path}/${driver_name_instance}/install.sh
+chmod 755 ${driver_path}/${driver_name_instance}/restart.sh
+chmod 755 ${driver_path}/${driver_name_instance}/uninstall.sh
+chmod 755 ${driver_path}/${driver_name_instance}/service/run
+chmod 755 ${driver_path}/${driver_name_instance}/service/log/run
+
+
+# copy default config file
+if [ ! -f ${driver_path}/${driver_name_instance}/config.ini ]; then
+    echo ""
+    echo ""
+    echo "First installation detected. Copying default config file..."
+    echo ""
+    echo "** Do not forget to edit the config file with your settings! **"
+    echo "You can edit the config file with the following command:"
+    echo "nano ${driver_path}/${driver_name_instance}/config.ini"
+    cp ${driver_path}/${driver_name_instance}/config.sample.ini ${driver_path}/${driver_name_instance}/config.ini
+    echo ""
+    echo "** Execute the install.sh script after you have edited the config file! **"
+    echo "You can execute the install.sh script with the following command:"
+    echo "bash ${driver_path}/${driver_name_instance}/install.sh"
+    echo ""
+else
+    echo ""
+    echo "Restaring driver to apply new version..."
+    /bin/bash ${driver_path}/${driver_name_instance}/restart.sh
+fi
+
+
+echo
+echo "Done."
+echo
+echo


### PR DESCRIPTION
It was somewhat awkward to have to use something like Node-RED to map the Shelly MQTT data to the format required by the original driver. So I coded a direct support for my Shelly devices.