### PR TITLE
Feature/standby power

### DIFF
--- a/dbus-mqtt-pv/config.sample.ini
+++ b/dbus-mqtt-pv/config.sample.ini
@@ -40,6 +40,9 @@ max = 3500
 ; 2 = AC input 2
 position = 0
 
+; standby power of the inverter in Watt. Reported measurements below this value get ignored
+standby_power = 1
+
 
 [MQTT]
 ; IP addess or FQDN from MQTT server

--- a/dbus-mqtt-pv/dbus-mqtt-pv.py
+++ b/dbus-mqtt-pv/dbus-mqtt-pv.py
@@ -153,7 +153,10 @@ def on_message(client, userdata, msg):
                     if isinstance(jsonpayload["pv"], dict):
                         if "power" in jsonpayload["pv"]:
                             pv_power = float(jsonpayload["pv"]["power"])
+                            pv_power_above_threshold = pv_power > standby_power
+                            pv_power = pv_power if pv_power_above_threshold else 0.0
                             pv_current = float(jsonpayload["pv"]["current"]) if "current" in jsonpayload["pv"] else pv_power / float(config["DEFAULT"]["voltage"])
+                            pv_current = pv_current if pv_power_above_threshold else 0.0
                             pv_voltage = float(jsonpayload["pv"]["voltage"]) if "voltage" in jsonpayload["pv"] else float(config["DEFAULT"]["voltage"])
                             if "energy_forward" in jsonpayload["pv"]:
                                 pv_forward = float(jsonpayload["pv"]["energy_forward"])
@@ -214,10 +217,11 @@ def on_message(client, userdata, msg):
 
                 elif "apower" in jsonpayload:
                     pv_power = float(jsonpayload.get("apower", 0))
-                    pv_power = pv_power if pv_power > standby_power else 0.0
+                    pv_power_above_threshold = pv_power > standby_power
+                    pv_power = pv_power if pv_power_above_threshold else 0.0
 
                     pv_current = float(jsonpayload.get("current", pv_power / float(config["DEFAULT"]["voltage"])))
-                    pv_current = pv_current if pv_current > standby_power else 0.0
+                    pv_current = pv_current if pv_power_above_threshold else 0.0
                     pv_voltage = float(jsonpayload.get("voltage", float(config["DEFAULT"]["voltage"])))
                     pv_forward = float(jsonpayload.get("aenergy").get("total")) / 1000 if "aenergy" in jsonpayload and "total" in jsonpayload["aenergy"] else None
 

--- a/dbus-mqtt-pv/dbus-mqtt-pv.py
+++ b/dbus-mqtt-pv/dbus-mqtt-pv.py
@@ -79,6 +79,7 @@ pv_power = -1
 pv_current = 0
 pv_voltage = 0
 pv_forward = 0
+standby_power = float(config["PV"].get("standby_power", "0"))
 
 pv_L1_power = None
 pv_L1_current = None
@@ -213,8 +214,10 @@ def on_message(client, userdata, msg):
 
                 elif "apower" in jsonpayload:
                     pv_power = float(jsonpayload.get("apower", 0))
+                    pv_power = pv_power if pv_power > standby_power else 0.0
 
                     pv_current = float(jsonpayload.get("current", pv_power / float(config["DEFAULT"]["voltage"])))
+                    pv_current = pv_current if pv_current > standby_power else 0.0
                     pv_voltage = float(jsonpayload.get("voltage", float(config["DEFAULT"]["voltage"])))
                     pv_forward = float(jsonpayload.get("aenergy").get("total")) / 1000 if "aenergy" in jsonpayload and "total" in jsonpayload["aenergy"] else None
 


### PR DESCRIPTION
I am using a Shelly Plus1PM to measure the power provided by a small plug-in solar system.
At night it measures a power consumption of 0.5W, which is apparently the standby power of the Hoymiles HMS800. 

Since the Shelly can not differentiate between incoming and outgoing current, these 0.5W are reported as generated PV Power. This doesn't look nice in the victron overview...

This PR adds a parameter "standby_power", which circumvents this "issue", by forcing values below the threshold to 0W before publishing it on the venus dbus.

The feature can be disabled by setting standby_power to a value <= 0