### PR TITLE
Add OpenInverterGateway MQTT payload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,30 @@ Tasmota Full Topic: %topic%/
 config.ini topic = SML/SENSOR
 ```
 
+### OpenInverterGateway
+
+```json
+{
+    "OutputPower": 1232.7,
+    "GridFrequency": 50.03,
+    "L1ThreePhaseGridVoltage": 229.8,
+    "L1ThreePhaseGridOutputCurrent": 2.4,
+    "L1ThreePhaseGridOutputPower": 551.5,
+    "L2ThreePhaseGridVoltage": 230.0,
+    "L2ThreePhaseGridOutputCurrent": 2.5,
+    "L2ThreePhaseGridOutputPower": 575.0,
+    "L3ThreePhaseGridVoltage": 230.3,
+    "L3ThreePhaseGridOutputCurrent": 2.5,
+    "L3ThreePhaseGridOutputPower": 106.2,
+    "TotalGenerateEnergy": 145606.8
+}
+```
+
+Only `OutputPower` is required. All other fields are optional.
+
+Ensure OpenInverterGateway publishes to the same MQTT topic as configured in `config.ini`.
+
+
 Additional information can be found in this [issue](https://github.com/mr-manuel/venus-os_dbus-mqtt-grid/issues/13#issue-2045377392).
 
 

--- a/dbus-mqtt-pv/dbus-mqtt-pv.py
+++ b/dbus-mqtt-pv/dbus-mqtt-pv.py
@@ -245,6 +245,39 @@ def on_message(client, userdata, msg):
                     pv_L3_frequency = None
                     pv_L3_forward = None
 
+                elif "OutputPower" in jsonpayload:
+                    pv_power = float(jsonpayload.get("OutputPower", 0))
+                    pv_power_above_threshold = pv_power > standby_power
+                    pv_power = pv_power if pv_power_above_threshold else 0.0
+
+                    pv_current = pv_power / float(config["DEFAULT"]["voltage"]) if pv_power_above_threshold else 0.0
+                    pv_voltage = float(jsonpayload.get("L1ThreePhaseGridVoltage", float(config["DEFAULT"]["voltage"])))
+                    pv_forward = float(jsonpayload.get("TotalGenerateEnergy")) if "TotalGenerateEnergy" in jsonpayload else None
+
+                    # L1
+                    pv_L1_power = float(jsonpayload.get("L1ThreePhaseGridOutputPower", 0))
+                    pv_L1_current = float(jsonpayload.get("L1ThreePhaseGridOutputCurrent", pv_L1_power / float(config["DEFAULT"]["voltage"])))
+                    pv_L1_voltage = float(jsonpayload.get("L1ThreePhaseGridVoltage", float(config["DEFAULT"]["voltage"])))
+                    pv_L1_frequency = float(jsonpayload.get("GridFrequency", float(config["DEFAULT"]["frequency"])))
+                    pv_L1_power_factor = None
+                    pv_L1_forward = None
+
+                    # L2
+                    pv_L2_power = float(jsonpayload.get("L2ThreePhaseGridOutputPower", 0))
+                    pv_L2_current = float(jsonpayload.get("L2ThreePhaseGridOutputCurrent", pv_L2_power / float(config["DEFAULT"]["voltage"])))
+                    pv_L2_voltage = float(jsonpayload.get("L2ThreePhaseGridVoltage", float(config["DEFAULT"]["voltage"])))
+                    pv_L2_frequency = float(jsonpayload.get("GridFrequency", float(config["DEFAULT"]["frequency"])))
+                    pv_L2_power_factor = None
+                    pv_L2_forward = None
+
+                    # L3
+                    pv_L3_power = float(jsonpayload.get("L3ThreePhaseGridOutputPower", 0))
+                    pv_L3_current = float(jsonpayload.get("L3ThreePhaseGridOutputCurrent", pv_L3_power / float(config["DEFAULT"]["voltage"])))
+                    pv_L3_voltage = float(jsonpayload.get("L3ThreePhaseGridVoltage", float(config["DEFAULT"]["voltage"])))
+                    pv_L3_frequency = float(jsonpayload.get("GridFrequency", float(config["DEFAULT"]["frequency"])))
+                    pv_L3_power_factor = None
+                    pv_L3_forward = None
+
                 else:
                     logging.error('Received JSON MQTT message does not include a pv object. Expected at least: {"pv": {"power": 0.0}}')
                     logging.debug("MQTT payload: " + str(msg.payload)[1:])


### PR DESCRIPTION
**Description**
This PR adds support for [OpenInverterGateway](https://github.com/OpenInverterGateway/OpenInverterGateway) MQTT payloads.

**Changes**
* Added parsing of OpenInverterGateway JSON payloads using the OutputPower field as the primary trigger.
* Added support for importing:
* Total output power (OutputPower)
* Total generated energy (TotalGenerateEnergy)
* Grid frequency (GridFrequency)
* Per-phase voltage, current, and power values for L1, L2, and L3
* Added OpenInverterGateway documentation to the README with an example MQTT payload.
* Supports both single-phase and three-phase inverter installations.

_Example payload_
```
{
  "OutputPower": 1232.7,
  "GridFrequency": 50.03,
  "L1ThreePhaseGridOutputPower": 551.5,
  "L2ThreePhaseGridOutputPower": 575.0,
  "L3ThreePhaseGridOutputPower": 106.2,
  "TotalGenerateEnergy": 145606.8
}
```

This allows dbus-mqtt-pv to be used directly with OpenInverterGateway without requiring MQTT payload transformations.